### PR TITLE
fix crash happening when tile gets activated

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -17,15 +17,9 @@ impl Plugin for WorldPlugin {
                 Update,
                 (
                     hover_tile,
-                    (
-                        highlight_hovered_tiles,
-                        (
-                            activate_hovered_tiles,
-                            activate_tiles,
-                            create_surrounding_tiles,
-                        )
-                            .chain(),
-                    ),
+                    (highlight_hovered_tiles, activate_hovered_tiles),
+                    create_surrounding_tiles,
+                    activate_tiles,
                 )
                     .chain(),
             )
@@ -276,6 +270,10 @@ fn create_surrounding_tiles(
     mut activate_tile_event: EventReader<ActivateTileEvent>,
     tiles: Query<&Transform, With<Tile>>,
 ) {
+    if activate_tile_event.is_empty() {
+        return;
+    }
+
     let mut filled_positions = tiles
         .iter()
         .map(|tile| {


### PR DESCRIPTION
this PR fixes a crash happening because of systems getting executed in the wrong order